### PR TITLE
feat: simplify bets

### DIFF
--- a/src/__tests__/prediction-market.test.js
+++ b/src/__tests__/prediction-market.test.js
@@ -20,7 +20,7 @@ describe('PredictionMarket', () => {
     const newMarket = market.getMarket()
 
     expect(newMarket).to.deep.equal({
-      SongCompetition: { outcomes: new Set(), participants: new Set(), bets: new Map() },
+      SongCompetition: { outcomes: new Set(), participants: new Set(), bets: {} },
     })
   })
 

--- a/src/__tests__/prediction-market.test.js
+++ b/src/__tests__/prediction-market.test.js
@@ -68,16 +68,16 @@ describe('PredictionMarket', () => {
     )
   })
 
-  // A test for resolveMarket(eventName, outcomeName) that resolves the market for a given event and outcome.
+  // Check the market resolution after all bets have been placed.
   it('should resolve the market for a given event and outcome', () => {
     market.createEvent('SongCompetition')
     market.addOutcomes('SongCompetition', ['Song A', 'Song B'])
     market.placeBet('SongCompetition', 'Song A', 'Alice', 100)
     market.placeBet('SongCompetition', 'Song B', 'Bob', 200)
     const newMarket = market.getMarket()
+
+    // Alice should win.
     const outcomes = market.resolveMarket('SongCompetition', 'Song A')
-    console.log(stringify(newMarket['SongCompetition'].bets))
-    console.log(outcomes)
     expect(stringify(outcomes)).to.equal('{"rewards":{"Alice":300,"Bob":0},"totalAmount":300}')
   })
 })

--- a/src/__tests__/prediction-market.test.js
+++ b/src/__tests__/prediction-market.test.js
@@ -10,7 +10,12 @@ describe('PredictionMarket', () => {
     market = new PredictionMarket()
   })
 
-  it('should create a new vanilla market without events', () => {
+  it('should create a new vanilla market without any events', () => {
+    const newMarket = market.getMarket()
+    expect(newMarket).to.deep.equal({})
+  })
+
+  it('should create a new market with an event without any outcomes', () => {
     market.createEvent('SongCompetition')
     const newMarket = market.getMarket()
 

--- a/src/prediction-market.js
+++ b/src/prediction-market.js
@@ -10,7 +10,7 @@ export default class PredictionMarket {
     this.market[eventName] = {
       outcomes: new Set(),
       participants: new Set(),
-      bets: new Map(),
+      bets: {},
     }
   }
 
@@ -45,11 +45,11 @@ export default class PredictionMarket {
 
     market.participants.add(participant)
 
-    if (!market.bets.has(outcomeName)) {
-      market.bets.set(outcomeName, [])
+    if (!market.bets[outcomeName]) {
+      market.bets[outcomeName] = []
     }
 
-    const bets = market.bets.get(outcomeName)
+    const bets = market.bets[outcomeName]
     bets.push([participant, amount])
   }
 
@@ -74,14 +74,13 @@ export default class PredictionMarket {
     )
 
     const bets = market.bets
-    // {"Song A":[["Alice",100]],"Song B":[["Bob",200]]}
-    const betValues = lodash.flatten([...bets.values()]).map(([_, amount]) => amount)
+    const betValues = flatten(Object.values(bets)).map(([_, amount]) => amount)
     const totalAmount = betValues.reduce((total, amount) => total + amount, 0)
 
     const rewards = {}
 
-    // participants keep what is they correctly bet
-    bets.forEach((specificBets, outcomeName) => {
+    // Participants keep the correctly places bets.
+    forEach(bets, (specificBets, outcomeName) => {
       specificBets.forEach(([participant, amount]) => {
         if (rewards[participant] === undefined) {
           rewards[participant] = 0
@@ -92,16 +91,17 @@ export default class PredictionMarket {
       })
     })
 
-    // calculate the total amount of bets on the winning outcome
-    const totalAmountOnWinningOutcome = bets
-      .get(winningOutcomeName)
-      .reduce((total, [_, amount]) => total + amount, 0)
+    // The total amount of bets on the winning outcome.
+    const totalAmountOnWinningOutcome = bets[winningOutcomeName].reduce(
+      (total, [_, amount]) => total + amount,
+      0
+    )
 
     // calculate the rest of the money
     const restOfTheMoney = totalAmount - totalAmountOnWinningOutcome
 
     // distribute the rest of the money among the winners proportionally to the amount of money they bet
-    bets.get(winningOutcomeName).forEach(([participant, amount]) => {
+    bets[winningOutcomeName].forEach(([participant, amount]) => {
       rewards[participant] += (amount / totalAmountOnWinningOutcome) * restOfTheMoney
     })
 


### PR DESCRIPTION
Simplify bets as a preparation for a small rehaul to make calculations more efficient.